### PR TITLE
[Fix]画像の比率が崩れないように修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -65,11 +65,18 @@ body {
   margin: 5px;
 }
 
+.fire-img {
+  object-fit: contain;
+  width: 250px;
+  height: 200px;
+}
+
 @media screen and (max-width:425px) {
 .fire-img {
 width:100%;
 max-width: 100%;
 height: auto;
+object-fit: contain;
 }
 }
 
@@ -78,6 +85,7 @@ height: auto;
 width:350px;
 max-width: 100%;
 height: auto;
+object-fit: contain;
 }
 }
 /*-------------top--------------*/
@@ -383,7 +391,9 @@ height: auto;
   }
 }
 
-#logo {
-  
+/*post/show,new 画像プレビュー*/
+#img_prev {
+  object-fit: contain;
+  width: 300px;
+  height: 250px;
 }
-

--- a/app/views/users/posts/_index.html.erb
+++ b/app/views/users/posts/_index.html.erb
@@ -2,7 +2,7 @@
     <div class="col-xs-12 col-md-6 col-lg-4">
         <table class="post-block">
         	<tr>
-				<td><%= link_to post_path(post) do %><%= attachment_image_tag post, :image, format: 'jpeg', size: "200x200", fallback: "no-image.jpg", class: "fire-img", data: {"turbolinks" => false}%>
+				<td><%= link_to post_path(post) do %><%= attachment_image_tag post, :image, format: 'jpeg', fallback: "no-image.jpg", class: "fire-img", data: {"turbolinks" => false}%>
 				    <% end %>
                 </td>
 			</tr>

--- a/app/views/users/posts/new.html.erb
+++ b/app/views/users/posts/new.html.erb
@@ -4,7 +4,7 @@
 
       <div class="col-xs-12 col-lg-5">
         <div class="img_box">
-        <%= attachment_image_tag @post, :image, fallback: "no-image.jpg", id: "img_prev", format: 'jpeg', size:"300x250" %>
+        <%= attachment_image_tag @post, :image, fallback: "no-image.jpg", id: "img_prev", format: 'jpeg'%>
         <%= f.attachment_field :image %>
         <!-- Googleマップ -->
          <%= render partial: 'google_maps',locals: { post: @post } %>


### PR DESCRIPTION
画像の横縦比が崩れてしまっていたためcssにobject-fit: contain;を記述
※このプロパティはCSS3から追加されたものであり、ChromeやFireFoxなどのモダンブラウザでしか動作対応していないため、対象とする端末のブラウザできちんと動作確認する必要あり

変更箇所
post/_index
.fire_img
→topやマイページに表示される投稿ブロックの画像表示に適用

#img_prev
→post/new,editとevent/new/editの画像プレビュー時に適用